### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/lewisgauss/694cfb56-bbf5-4f6a-ad4d-b6517c875b4b/874ef0e2-768d-4022-9c84-647d44571b04/_apis/work/boardbadge/f43fcea1-c74a-4afe-ba83-c952bc13e819)](https://dev.azure.com/lewisgauss/694cfb56-bbf5-4f6a-ad4d-b6517c875b4b/_boards/board/t/874ef0e2-768d-4022-9c84-647d44571b04/Microsoft.RequirementCategory)
 <!-- AUTO-GENERATED-CONTENT:START (STARTER) -->
 <p align="center">
   <a href="https://www.gatsbyjs.org">


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/lewisgauss/694cfb56-bbf5-4f6a-ad4d-b6517c875b4b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.